### PR TITLE
Add unit tests for AuthService and AuthGuard, Re-structure NavigationService tests

### DIFF
--- a/src/app/auth/auth.guard.spec.ts
+++ b/src/app/auth/auth.guard.spec.ts
@@ -1,19 +1,76 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { TestBed, async } from '@angular/core/testing';
 
 import { AuthGuard } from './auth.guard';
+import { AuthService } from './auth.service';
+
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { sideNavPath } from '../nav-routing';
+import {
+    Router,
+    ActivatedRouteSnapshot,
+    RouterStateSnapshot,
+} from '@angular/router';
+
+class MockAuthService {
+    redirectUrl = '';
+    token = '';
+
+    isLogged() {
+        return '';
+    }
+}
 
 describe('AuthGuard', () => {
-    beforeEach(() => {
+    let guard: AuthGuard;
+    let service: AuthService;
+    let router: Router;
+
+    beforeEach(async (() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule, RouterTestingModule],
-            providers: [AuthGuard],
+            imports: [
+                HttpClientTestingModule,
+                RouterTestingModule.withRoutes([]),
+            ],
+            providers: [
+                { provide: AuthService, useClass: MockAuthService },
+                AuthGuard,
+            ],
         });
+        guard = TestBed.get(AuthGuard);
+        service = TestBed.get(AuthService);
+        router = TestBed.get(Router);
+    }));
+
+    it('should be created', () => {
+        expect(guard).toBeTruthy();
     });
 
-    it('should ...', inject([AuthGuard], (guard: AuthGuard) => {
-        expect(guard).toBeTruthy();
-    }));
+    describe('canActivate', () => {
+        it('set the redirectUrl to null and return true', () => {
+            spyOn(service, 'isLogged').and.returnValue(true);
+
+            expect(
+                guard.canActivate(
+                    {} as ActivatedRouteSnapshot,
+                    { url: 'fakeUrl' } as RouterStateSnapshot,
+                ),
+            ).toEqual(true);
+            expect(service.redirectUrl).toBeNull();
+        });
+
+        it('should set the redirectUrl, call router.navigate, and return false', () => {
+            spyOn(router, 'navigate');
+            spyOn(service, 'isLogged').and.returnValue(false);
+
+            expect(
+                guard.canActivate(
+                    {} as ActivatedRouteSnapshot,
+                    { url: 'fakeUrl' } as RouterStateSnapshot,
+                ),
+            ).toEqual(false);
+            expect(service.redirectUrl).toEqual('fakeUrl');
+            expect(router.navigate).toHaveBeenCalledWith(['']);
+        });
+    });
 });

--- a/src/app/auth/auth.service.spec.ts
+++ b/src/app/auth/auth.service.spec.ts
@@ -1,17 +1,97 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed, async } from '@angular/core/testing';
 
 import { AuthService } from './auth.service';
+import { StorageService } from '../core/services/storage/storage.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
+class MockStorageService {
+    read() {
+        return true;
+    }
+
+    save() {
+        return true;
+    }
+
+    remove() {
+        return true;
+    }
+}
+
 describe('AuthService', () => {
-    beforeEach(() =>
+    let authService: AuthService;
+    let storageService: StorageService;
+
+    beforeEach(async (() => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
-        }),
-    );
+            providers: [
+                { provide: StorageService, useClass: MockStorageService },
+                AuthService,
+            ],
+        });
+        authService = TestBed.get(AuthService);
+        storageService = TestBed.get(StorageService);
+    }));
 
     it('should be created', () => {
-        const service: AuthService = TestBed.get(AuthService);
-        expect(service).toBeTruthy();
+        expect(authService).toBeTruthy();
+    });
+
+    describe('mockLogin', () => {
+        it('save the token to storage and return the redirectUrl', () => {
+            spyOn(storageService, 'save');
+            authService.redirectUrl = '/welcome';
+
+            authService
+                .mockLogin('user', 'user')
+                .then((redirectUrl: string) => {
+                    expect(storageService.save).toHaveBeenCalled();
+                    expect(redirectUrl).toEqual('/welcome');
+                });
+        });
+
+        it('should throw an error and reject the promise in the catch block', () => {
+            spyOn(Promise, 'reject');
+            const errorText =
+                'When using mockLogin, login with credentials: \nemail: user\npassword:user';
+
+            authService
+                .mockLogin('badUser', 'badPassword')
+                .then(() => {})
+                .catch(() => {
+                    expect(Promise.reject).toHaveBeenCalledWith(errorText);
+                });
+        });
+    });
+
+    describe('getToken', () => {
+        it('should get the correct token', () => {
+            authService.token = 'fakeTokenValue';
+            expect(authService.getToken()).toEqual('fakeTokenValue');
+        });
+    });
+
+    describe('logout', () => {
+        it('should set the token to an empty string and remove the auth token from storage', () => {
+            spyOn(storageService, 'remove');
+
+            authService.logout();
+
+            expect(authService.token).toEqual('');
+            expect(storageService.remove).toHaveBeenCalled();
+        });
+    });
+
+    describe('isLogged', () => {
+        it('should return true if the token length is greater than 0', () => {
+            authService.token = 'fakeTokenValue';
+            expect(authService.isLogged()).toEqual(true);
+        });
+
+        it('should return false if the token length is not greater than 0', () => {
+            authService.token = '';
+            expect(authService.isLogged()).toEqual(false);
+        });
     });
 });

--- a/src/app/core/services/navigation/navigation.service.spec.ts
+++ b/src/app/core/services/navigation/navigation.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed, async } from '@angular/core/testing';
 
 import { NavigationService } from './navigation.service';
 import { NavRoute } from '../../../nav-routing';
@@ -16,7 +16,7 @@ describe('NavigationService', () => {
         getNavRoutes: () => mockNavRouteItems,
     };
 
-    beforeEach(() => {
+    beforeEach(async (() => {
         TestBed.configureTestingModule({
             providers: [
                 {
@@ -26,41 +26,51 @@ describe('NavigationService', () => {
             ],
         });
         service = TestBed.get(NavigationService);
-    });
+    }));
 
     it('should be created', () => {
         expect(service).toBeTruthy();
     });
 
-    it('should get the correct navigationItems', () => {
-        expect(service.getNavigationItems()).toEqual(mockNavRouteItems);
+    describe('getNavigationItems', () => {
+        it('should get the correct navigationItems', () => {
+            expect(service.getNavigationItems()).toEqual(mockNavRouteItems);
+        });
     });
 
-    it('should set the activePage', () => {
-        service.setActivePage('fakeTitle', true);
-        const activePage = service.getActivePage();
-        expect(activePage.title).toEqual('fakeTitle');
-        expect(activePage.isChild).toEqual(true);
+    describe('setActivePage', () => {
+        it('should set the activePage', () => {
+            service.setActivePage('fakeTitle', true);
+            const activePage = service.getActivePage();
+            expect(activePage.title).toEqual('fakeTitle');
+            expect(activePage.isChild).toEqual(true);
+        });
     });
 
-    it('should get the activePage', () => {
-        service.setActivePage('fakeTitle', false);
-        const activePage = service.getActivePage();
-        expect(service.getActivePage()).toEqual(activePage);
+    describe('getActivePage', () => {
+        it('should get the activePage', () => {
+            service.setActivePage('fakeTitle', false);
+            const activePage = service.getActivePage();
+            expect(service.getActivePage()).toEqual(activePage);
+        });
     });
 
-    it('should get the correct selectedNavigationItem by the item path', () => {
-        spyOn(service, 'setActivePage');
+    describe('selectNavigationItemByPath', () => {
+        it('should get the correct selectedNavigationItem by the item path', () => {
+            spyOn(service, 'setActivePage');
 
-        service.selectNavigationItemByPath('somePath');
-        expect(service.setActivePage).toHaveBeenCalledWith(
-            mockNavRouteItems[0].data.title,
-        );
+            service.selectNavigationItemByPath('somePath');
+            expect(service.setActivePage).toHaveBeenCalledWith(
+                mockNavRouteItems[0].data.title,
+            );
+        });
     });
 
-    it('should get the correct selectedNavigationItem', () => {
-        const navigationItem = mockNavRouteItems[0];
-        service.selectNavigationItemByPath(navigationItem.path);
-        expect(service.getSelectedNavigationItem()).toEqual(navigationItem);
+    describe('getSelectedNavigationItem', () => {
+        it('should get the correct selectedNavigationItem', () => {
+            const navigationItem = mockNavRouteItems[0];
+            service.selectNavigationItemByPath(navigationItem.path);
+            expect(service.getSelectedNavigationItem()).toEqual(navigationItem);
+        });
     });
 });


### PR DESCRIPTION
This PR adds unit tests for the `AuthGuard` and `AuthService`, and puts the methods under test into their own describe blocks for the `NavigationService` for better clarity and organization.